### PR TITLE
feat: add fire-and-forget mode

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - checkout
       - saucectl/saucectl-run:
+          async: true
           show-console-log: true
           config-file: ./.sauce/config.yml
           region: us-west-1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,10 +20,14 @@ jobs:
     steps:
       - checkout
       - saucectl/saucectl-run:
-          async: true
           show-console-log: true
           config-file: ./.sauce/config.yml
           region: us-west-1
+          working-directory: ./tests/
+          select-suite: saucy test on sauce
+      - saucectl/saucectl-run:
+          async: true
+          config-file: ./.sauce/config.yml
           working-directory: ./tests/
           select-suite: saucy test on sauce
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v3.0.0 - 9/18/2023
+## v3.0.0 - 9/19/2023
 ### Added
 - Integration of the latest orb configuration files, including `config.yml` and `test-deploy.yml`.
+- Support for `async` params.
 ### Removed
 - saucectl Docker configuration and related documentation.
 ### Updated

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Alternatively, you can use the `sauce-username` and `sauce-access-key` parameter
 | ccy | Sets the concurrency to be used for the run | |
 | retries | Sets the number of retries to do for the run | |
 | test-env-silent | Skips the test environment announcement | false |
+| async | Launches tests without awaiting outcomes; operates in a fire-and-forget manner | false |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Alternatively, you can use the `sauce-username` and `sauce-access-key` parameter
 | tunnel-owner | Sets the sauce-connect tunnel owner to be used for the run | |
 | ccy | Sets the concurrency to be used for the run | |
 | retries | Sets the number of retries to do for the run | |
-| test-env-silent | Skips the test environment announcement | false |
-| async | Launches tests without awaiting outcomes; operates in a fire-and-forget manner | false |
+| test-env-silent | Skips the test environment announcement | `false` |
+| async | Launches tests without awaiting outcomes; operates in a fire-and-forget manner | `false` |
 
 ## Example
 

--- a/src/commands/saucectl-run.yml
+++ b/src/commands/saucectl-run.yml
@@ -70,6 +70,10 @@ parameters:
     type: boolean
     description: Skips the test environment announcement.
     default: false
+  async:
+    type: boolean
+    description: Launches tests without awaiting outcomes; operates in a fire-and-forget manner.
+    default: false
 
 steps:
   - run:
@@ -90,5 +94,6 @@ steps:
         PARAM_CCY: <<parameters.ccy>>
         PARAM_RETRIES: <<parameters.retries>>
         PARAM_TEST_ENV_SILENT: <<parameters.test-env-silent>>
+        PARAM_ASYNC: <<parameters.async>>
       name: run saucectl
       command: <<include(scripts/saucectl-run.sh)>>

--- a/src/scripts/saucectl-run.sh
+++ b/src/scripts/saucectl-run.sh
@@ -117,6 +117,10 @@ parse_args() {
     if [ -n "${PARAM_TEST_ENV_SILENT}" ];then
         ARGS+=("--test-env-silent")
     fi
+
+    if [ -n "${PARAM_ASYNC}" ];then
+        ARGS+=("--async")
+    fi
 }
 
 run() {


### PR DESCRIPTION
Support `--async` flag.

Workable job: https://app.circleci.com/pipelines/github/saucelabs/saucectl-run-orb/175/workflows/2ecad1b3-5942-4dae-9a39-3800b46a04a4/jobs/565/parallel-runs/0/steps/0-102